### PR TITLE
[FEAT] 내 설문 목록 페이지 기초 퍼블리싱 작업

### DIFF
--- a/src/app/my-surveys/page.tsx
+++ b/src/app/my-surveys/page.tsx
@@ -1,0 +1,108 @@
+import SearchInput from '@/components/ui/search-input'
+import CreateSurveyCard from '@/components/my-serveys/create-survey-card'
+import SurveyList from '@/components/my-serveys/survey-list'
+import ToolbarControls from '@/components/my-serveys/toolbar-controls'
+import type { SurveyItem, SurveyCardExtras } from '@/types/survey'
+
+// 데모용 목데이터 (API 연동 전)
+const mock: SurveyItem[] = [
+  {
+    id: '1',
+    title: '여름 아이스커피 취향 설문',
+    thumbnail: '/images/sample-1.png',
+    reward: { type: 'gifticon', value: 1, giftName: '커피' },
+    duration: 3,
+    tags: ['음료', '취향'],
+  },
+  {
+    id: '2',
+    title: '앱 사용성 만족도 조사',
+    thumbnail: '/images/sample-2.png',
+    reward: { type: 'point', value: 500 },
+    duration: 5,
+  },
+  {
+    id: '3',
+    title: '주간 뉴스레터 피드백',
+    thumbnail: '/images/sample-3.png',
+    reward: { type: 'point', value: 300 },
+    duration: 4,
+  },
+]
+
+// 카드 보조정보 (선택)
+const extrasById: Record<string, SurveyCardExtras> = {
+  '1': {
+    status: 'ongoing',
+    period: { startAt: '2025-01-01', endAt: null },
+    participants: { current: 120, target: 200 },
+  },
+  '2': {
+    status: 'closed',
+    period: { startAt: '2025-02-01', endAt: '2025-03-01' },
+    participants: { current: 80, target: 80 },
+  },
+  '3': {
+    status: 'closed',
+    period: { startAt: '2025-03-10', endAt: '2025-03-31' },
+    participants: { current: 45, target: 100 },
+  },
+}
+
+export default async function Page(props: {
+  searchParams: { q?: string; view?: string; status?: string }
+}) {
+  const searchParams = await props.searchParams
+  const q = typeof searchParams.q === 'string' ? searchParams.q : ''
+  const view: 'list' | 'grid' = searchParams.view === 'grid' ? 'grid' : 'list'
+  const status =
+    searchParams.status === 'ongoing' || searchParams.status === 'closed'
+      ? searchParams.status
+      : undefined
+
+  // TODO: q를 이용해 서버에서 실제 데이터 필터/조회
+  let items = q ? mock.filter((it) => it.title.includes(q)) : mock
+  if (status) {
+    items = items.filter(
+      (it) => (extrasById[it.id]?.status ?? 'ongoing') === status,
+    )
+  }
+
+  return (
+    <main className="flex-1">
+      <div className="mx-auto max-w-6xl px-6 py-8 space-y-6">
+        {/* 페이지 타이틀 */}
+        <div className="flex items-center justify-between flex-wrap gap-4">
+          <h2 className="text-2xl font-semibold">내 설문 목록</h2>
+          <div className="flex items-center gap-4">
+            <SearchInput
+              action="/my-surveys"
+              defaultValue={q}
+              hiddenParams={{
+                view: view === 'grid' ? 'grid' : undefined,
+                status,
+              }}
+            />
+            <ToolbarControls
+              path="/my-surveys"
+              q={q}
+              view={view}
+              status={status}
+            />
+          </div>
+        </div>
+
+        {/* 새 설문 만들기 카드 */}
+        {view === 'list' ? <CreateSurveyCard /> : null}
+
+        {/* 설문 리스트 */}
+        <SurveyList
+          items={items}
+          extrasById={extrasById}
+          view={view}
+          showNewTile={view === 'grid'}
+        />
+      </div>
+    </main>
+  )
+}

--- a/src/app/my-surveys/page.tsx
+++ b/src/app/my-surveys/page.tsx
@@ -50,7 +50,7 @@ const extrasById: Record<string, SurveyCardExtras> = {
 }
 
 export default async function Page(props: {
-  searchParams: { q?: string; view?: string; status?: string }
+  searchParams: Promise<{ q?: string; view?: string; status?: string }>
 }) {
   const searchParams = await props.searchParams
   const q = typeof searchParams.q === 'string' ? searchParams.q : ''

--- a/src/components/home/best-reward-products-section.tsx
+++ b/src/components/home/best-reward-products-section.tsx
@@ -14,7 +14,7 @@ export function BestRewardProductsSection({
     <section>
       <SectionHeader
         title="BEST! 리워드 추천 상품"
-        moreHref="/reward"
+        moreHref="/reward-shop"
       />
       <ResponsiveSliderGrid>
         {items.map((p) => (

--- a/src/components/home/status-section.tsx
+++ b/src/components/home/status-section.tsx
@@ -7,8 +7,8 @@ export function StatusSection({
   newResponseCount,
   newResponseSurveyTitle,
   weeklyPoints,
-  responseHref = '/mysurvey',
-  pointsHref = '/mypage',
+  responseHref = '/my-surveys',
+  pointsHref = '/my-page',
   cardHeightClass = 'h-28 md:h-32',
 }: {
   newResponseCount: number

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -2,50 +2,103 @@
 
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { cn } from '@/lib/utils'
+import { useState } from 'react'
+import ProfilePanel from '@/components/layout/profile-panel'
+
+function NavLink({ href, label }: { href: string; label: string }) {
+  const pathname = usePathname()
+  const isActive = pathname.startsWith(href)
+  return (
+    <Link
+      href={href}
+      aria-current={isActive ? 'page' : undefined}
+      className={`text-sm transition hover:text-gray-900 ${
+        isActive ? 'text-gray-900 font-medium' : 'text-gray-600'
+      }`}
+    >
+      {label}
+    </Link>
+  )
+}
 
 export function Header() {
-  const pathname = usePathname()
+  const points = 0
+  const hasNotification = true
+  const [openProfile, setOpenProfile] = useState(false)
+  const isAuthed = true // 실제 인증 상태로 교체
 
   return (
     <header className="sticky top-0 z-40 w-full border-b bg-white px-6 py-3">
-      <nav className="flex items-center justify-between">
-        <Link
-          href="/"
-          className="text-xl font-bold"
-        >
-          Logo
-        </Link>
-        <div className="flex gap-4">
+      <div className="mx-auto max-w-6xl h-16 px-6 flex items-center justify-between gap-6">
+        {/* 좌: 로고 + 서비스명 */}
+        <div className="flex items-center gap-3">
           <Link
-            href="/survey"
-            className={cn(
-              'hover:text-blue-600',
-              pathname.startsWith('/survey') && 'text-blue-600 font-medium',
-            )}
+            href="/"
+            className="text-lg font-semibold tracking-tight"
           >
-            설문조사
-          </Link>
-          <Link
-            href="/mysurvey"
-            className={cn(
-              'hover:text-blue-600',
-              pathname.startsWith('/my') && 'text-blue-600 font-medium',
-            )}
-          >
-            내 설문
-          </Link>
-          <Link
-            href="/reward"
-            className={cn(
-              'hover:text-blue-600',
-              pathname.startsWith('/reward') && 'text-blue-600 font-medium',
-            )}
-          >
-            리워드샵
+            Pollet
           </Link>
         </div>
-      </nav>
+
+        {/* 중간: 1차 내비게이션 */}
+        <nav className="hidden md:flex items-center gap-8">
+          <NavLink
+            href="/survey"
+            label="설문조사"
+          />
+          <NavLink
+            href="/my-surveys"
+            label="내 설문"
+          />
+          <NavLink
+            href="/reward-shop"
+            label="리워드샵"
+          />
+        </nav>
+
+        {/* 우: 포인트 / 등급 / 알림 / 프로필 */}
+        <div className="flex items-center gap-4">
+          <div className="flex items-center gap-1 text-sm text-gray-900">
+            {/* <PiggyBank className="size-5" /> */}
+            <span className="tabular-nums">
+              {points.toLocaleString('ko-KR', { minimumIntegerDigits: 1 })}
+            </span>
+            <span className="text-xs text-gray-500">p</span>
+          </div>
+
+          <button
+            aria-label="내 등급"
+            className="p-1 rounded hover:bg-gray-100"
+          >
+            {/* <Shield className="size-5 text-gray-700" /> */}
+          </button>
+
+          <Link
+            href="/notifications"
+            aria-label="알림"
+            className="relative p-1 rounded hover:bg-gray-100"
+          >
+            {/* <Bell className="size-5 text-gray-700" /> */}
+            {hasNotification && (
+              <span className="absolute right-1 top-1 h-2 w-2 rounded-full bg-red-500" />
+            )}
+          </Link>
+
+          <button
+            aria-label="내 프로필"
+            className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-gray-200"
+            onClick={() => setOpenProfile(true)}
+          >
+            {/* <User className="size-4 text-gray-700" /> */}
+          </button>
+        </div>
+      </div>
+      {/* 프로필 패널 */}
+      <ProfilePanel
+        open={openProfile}
+        onClose={() => setOpenProfile(false)}
+        isAuthed={isAuthed}
+      />
     </header>
   )
 }

--- a/src/components/layout/profile-panel.tsx
+++ b/src/components/layout/profile-panel.tsx
@@ -1,0 +1,126 @@
+'use client'
+import { useEffect, useRef } from 'react'
+// import { X, User } from 'lucide-react'
+import { useRouter } from 'next/navigation'
+
+interface Props {
+  open: boolean
+  onClose: () => void
+  isAuthed: boolean
+}
+
+export default function ProfilePanel({ open, onClose, isAuthed }: Props) {
+  const router = useRouter()
+  const panelRef = useRef<HTMLDivElement | null>(null)
+
+  const go = (path: string) => {
+    onClose()
+    router.push(path)
+  }
+
+  const logout = () => {
+    // TODO: 실제 로그아웃 로직으로 교체 (예: next-auth signOut())
+    onClose()
+    router.push('/logout')
+  }
+
+  // ESC 닫기 + 스크롤 락 + 포커스 이동
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    if (open) {
+      window.addEventListener('keydown', onKey)
+      const prev = document.documentElement.style.overflow
+      document.documentElement.style.overflow = 'hidden'
+      // 첫 포커스 버튼으로 이동
+      setTimeout(() => {
+        const el =
+          panelRef.current?.querySelector<HTMLButtonElement>('button, a')
+        el?.focus()
+      }, 0)
+      return () => {
+        window.removeEventListener('keydown', onKey)
+        document.documentElement.style.overflow = prev
+      }
+    }
+  }, [open, onClose])
+
+  return (
+    <>
+      {/* 오버레이 */}
+      <div
+        className={`fixed inset-0 z-40 transition-opacity duration-200 ${
+          open
+            ? 'opacity-100 pointer-events-auto bg-black/20'
+            : 'opacity-0 pointer-events-none'
+        }`}
+        onClick={onClose}
+        aria-hidden
+      />
+
+      {/* 패널 */}
+      <aside
+        ref={panelRef}
+        className={`fixed right-0 top-0 z-50 h-dvh w-80 max-w-[90vw] bg-white shadow-2xl flex flex-col transform transition-transform duration-300 ease-out will-change-transform
+          ${open ? 'translate-x-0' : 'translate-x-full'}`}
+        role="dialog"
+        aria-modal="true"
+        aria-label="프로필 메뉴"
+        aria-hidden={!open}
+      >
+        <div className="flex items-center justify-between px-5 h-14 border-b">
+          <div className="flex items-center gap-2 text-gray-900">
+            <span className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-gray-200">
+              {/* <User className="size-4 text-gray-700" /> */}
+            </span>
+            <span className="font-medium">
+              {isAuthed ? '내 계정' : '시작하기'}
+            </span>
+          </div>
+          <button
+            aria-label="닫기"
+            onClick={onClose}
+            className="p-2 rounded hover:bg-gray-100"
+          >
+            {/* <X className="size-5" /> */}
+          </button>
+        </div>
+
+        <div className="p-5 space-y-3">
+          {isAuthed ? (
+            <>
+              <button
+                onClick={() => go('/my-page')}
+                className="w-full rounded-md border px-4 py-3 text-left hover:bg-gray-50"
+              >
+                마이페이지
+              </button>
+              <button
+                onClick={logout}
+                className="w-full rounded-md bg-gray-900 text-white px-4 py-3 hover:opacity-90"
+              >
+                로그아웃
+              </button>
+            </>
+          ) : (
+            <>
+              <button
+                onClick={() => go('/login')}
+                className="w-full rounded-md bg-gray-900 text-white px-4 py-3 hover:opacity-90"
+              >
+                로그인
+              </button>
+              <button
+                onClick={() => go('/signup')}
+                className="w-full rounded-md border px-4 py-3 hover:bg-gray-50"
+              >
+                회원가입
+              </button>
+            </>
+          )}
+        </div>
+      </aside>
+    </>
+  )
+}

--- a/src/components/my-serveys/create-survey-card.tsx
+++ b/src/components/my-serveys/create-survey-card.tsx
@@ -1,0 +1,12 @@
+export default function CreateSurveyCard() {
+  return (
+    <button className="w-full rounded-md border-2 border-gray-300 bg-white hover:border-gray-400 hover:bg-gray-50 transition">
+      <div className="px-6 py-5 flex items-center justify-center gap-3">
+        <span className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-gray-200">
+          {/* <Plus className="size-5 text-gray-700" /> */}
+        </span>
+        <span className="text-gray-700">새 설문 만들기</span>
+      </div>
+    </button>
+  )
+}

--- a/src/components/my-serveys/create-survey-tile.tsx
+++ b/src/components/my-serveys/create-survey-tile.tsx
@@ -1,0 +1,12 @@
+// import { Plus } from 'lucide-react'
+
+export default function CreateSurveyTile() {
+  return (
+    <button className="rounded-md border bg-gray-100 overflow-hidden">
+      <span className="inline-flex h-25 w-25 items-center justify-center rounded-full bg-gray-200">
+        {/* <Plus className="size-6 text-gray-700" /> */}
+      </span>
+      <div className="px-3 py-2 text-sm text-gray-700">새 설문 만들기</div>
+    </button>
+  )
+}

--- a/src/components/my-serveys/create-survey-tile.tsx
+++ b/src/components/my-serveys/create-survey-tile.tsx
@@ -2,11 +2,13 @@
 
 export default function CreateSurveyTile() {
   return (
-    <button className="rounded-md border bg-gray-100 overflow-hidden">
-      <span className="inline-flex h-25 w-25 items-center justify-center rounded-full bg-gray-200">
-        {/* <Plus className="size-6 text-gray-700" /> */}
-      </span>
-      <div className="px-3 py-2 text-sm text-gray-700">새 설문 만들기</div>
+    <button className="w-full rounded-md border-2 border-gray-300 bg-white hover:border-gray-400 hover:bg-gray-50 transition">
+      <div className="px-6 py-5 flex flex-col items-center justify-center gap-3">
+        <span className="inline-flex h-25 w-25 items-center justify-center rounded-full bg-gray-200">
+          {/* <Plus className="size-6 text-gray-700" /> */}
+        </span>
+        <span className="text-gray-700">새 설문 만들기</span>
+      </div>
     </button>
   )
 }

--- a/src/components/my-serveys/filter-popover.tsx
+++ b/src/components/my-serveys/filter-popover.tsx
@@ -1,0 +1,50 @@
+import Link from 'next/link'
+// import { Filter } from 'lucide-react'
+
+interface Props {
+  path: string
+  q?: string
+  view?: 'list' | 'grid'
+  status?: 'ongoing' | 'closed'
+}
+
+function buildHref(
+  path: string,
+  {
+    q,
+    view,
+    status,
+  }: { q?: string; view?: 'list' | 'grid'; status?: 'ongoing' | 'closed' },
+) {
+  const sp = new URLSearchParams()
+  if (q) sp.set('q', q)
+  if (view === 'grid') sp.set('view', 'grid')
+  if (status) sp.set('status', status)
+  const qs = sp.toString()
+  return qs ? `${path}?${qs}` : path
+}
+
+export default function FilterPopover({ path, q, view, status }: Props) {
+  return (
+    <details className="relative inline-block">
+      <summary className="list-none cursor-pointer inline-flex items-center gap-2 rounded-md px-3 py-2 hover:bg-gray-100 whitespace-nowrap">
+        {/* <Filter className="size-5" /> */}
+        <span className="hidden sm:inline">필터</span>
+      </summary>
+      <div className="absolute right-0 mt-2 w-40 rounded-md border bg-white shadow">
+        <Link
+          href={buildHref(path, { q, view, status: 'ongoing' })}
+          className="block px-3 py-2 text-sm hover:bg-gray-50"
+        >
+          진행중만
+        </Link>
+        <Link
+          href={buildHref(path, { q, view, status: 'closed' })}
+          className="block px-3 py-2 text-sm hover:bg-gray-50"
+        >
+          종료만
+        </Link>
+      </div>
+    </details>
+  )
+}

--- a/src/components/my-serveys/filter-popover.tsx
+++ b/src/components/my-serveys/filter-popover.tsx
@@ -25,22 +25,36 @@ function buildHref(
 }
 
 export default function FilterPopover({ path, q, view, status }: Props) {
+  const isOngoing = status === 'ongoing'
+  const isClosed = status === 'closed'
+  const label =
+    status === 'ongoing'
+      ? '필터: 진행중'
+      : status === 'closed'
+        ? '필터: 종료'
+        : '필터'
   return (
     <details className="relative inline-block">
       <summary className="list-none cursor-pointer inline-flex items-center gap-2 rounded-md px-3 py-2 hover:bg-gray-100 whitespace-nowrap">
         {/* <Filter className="size-5" /> */}
-        <span className="hidden sm:inline">필터</span>
+        <span className="hidden sm:inline">{label}</span>
       </summary>
       <div className="absolute right-0 mt-2 w-40 rounded-md border bg-white shadow">
         <Link
           href={buildHref(path, { q, view, status: 'ongoing' })}
-          className="block px-3 py-2 text-sm hover:bg-gray-50"
+          aria-current={isOngoing ? 'page' : undefined}
+          className={`block px-3 py-2 text-sm hover:bg-gray-50 ${
+            isOngoing ? 'text-gray-900 font-medium' : 'text-gray-700'
+          }`}
         >
           진행중만
         </Link>
         <Link
           href={buildHref(path, { q, view, status: 'closed' })}
-          className="block px-3 py-2 text-sm hover:bg-gray-50"
+          aria-current={isClosed ? 'page' : undefined}
+          className={`block px-3 py-2 text-sm hover:bg-gray-50 ${
+            isClosed ? 'text-gray-900 font-medium' : 'text-gray-700'
+          }`}
         >
           종료만
         </Link>

--- a/src/components/my-serveys/filter-popover.tsx
+++ b/src/components/my-serveys/filter-popover.tsx
@@ -34,7 +34,7 @@ export default function FilterPopover({ path, q, view, status }: Props) {
         ? '필터: 종료'
         : '필터'
   return (
-    <details className="relative inline-block">
+    <details className="relative inline-block z-10">
       <summary className="list-none cursor-pointer inline-flex items-center gap-2 rounded-md px-3 py-2 hover:bg-gray-100 whitespace-nowrap">
         {/* <Filter className="size-5" /> */}
         <span className="hidden sm:inline">{label}</span>

--- a/src/components/my-serveys/survey-card.tsx
+++ b/src/components/my-serveys/survey-card.tsx
@@ -1,0 +1,53 @@
+import StatusBadge from '@/components/ui/badges'
+import type { SurveyItem, SurveyCardExtras } from '@/types/survey'
+
+interface Props {
+  item: SurveyItem
+  extras?: SurveyCardExtras
+}
+
+function formatPeriod(startAt: string, endAt: string | null) {
+  const s = startAt.replaceAll('-', '.')
+  const e = endAt ? endAt.replaceAll('-', '.') : null
+  return e ? `${s} ~ ${e}` : `${s} ~ 종료기간 없음`
+}
+
+export default function SurveyCard({ item, extras }: Props) {
+  const status = extras?.status ?? 'ongoing'
+  const hasPeriod = !!extras?.period
+  const participants = extras?.participants
+
+  return (
+    <li className="bg-gray-100 hover:bg-gray-200 transition rounded-md">
+      <button className="w-full text-left">
+        <div className="flex items-center gap-5 px-6 py-5">
+          {/* 항상 상태 배지 표시 */}
+          <div className="pt-1 shrink-0">
+            <StatusBadge status={status} />
+          </div>
+
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-gray-800">{item.title}</p>
+            {hasPeriod && (
+              <p className="mt-1 text-xs text-gray-600">
+                {formatPeriod(extras!.period!.startAt, extras!.period!.endAt)}
+              </p>
+            )}
+          </div>
+
+          <div className="shrink-0 inline-flex items-center gap-2 text-xs text-gray-600">
+            {participants && (
+              <div className="shrink-0 inline-flex items-center gap-2 text-xs text-gray-600">
+                {/* <Users className="size-4" /> */}
+                <span>
+                  {String(participants.current).padStart(4, '0')}/
+                  {String(participants.target ?? 0).padStart(4, '0')}
+                </span>
+              </div>
+            )}
+          </div>
+        </div>
+      </button>
+    </li>
+  )
+}

--- a/src/components/my-serveys/survey-list.tsx
+++ b/src/components/my-serveys/survey-list.tsx
@@ -26,7 +26,7 @@ export default function SurveyList({
   }
   if (view === 'grid') {
     return (
-      <ul className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+      <ul className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
         {showNewTile && <CreateSurveyTile />}
         {items.map((it) => (
           <SurveyTile

--- a/src/components/my-serveys/survey-list.tsx
+++ b/src/components/my-serveys/survey-list.tsx
@@ -1,0 +1,52 @@
+import SurveyCard from './survey-card'
+import SurveyTile from './survey-tile'
+import CreateSurveyTile from './create-survey-tile'
+import type { SurveyItem, SurveyCardExtras } from '@/types/survey'
+
+interface Props {
+  items: SurveyItem[]
+  /** key = survey.id */
+  extrasById?: Record<string, SurveyCardExtras>
+  view?: 'list' | 'grid'
+  showNewTile?: boolean
+}
+
+export default function SurveyList({
+  items,
+  extrasById,
+  view = 'list',
+  showNewTile = false,
+}: Props) {
+  if (!items.length) {
+    return (
+      <div className="text-center text-sm text-gray-500 py-16">
+        등록된 설문이 없습니다.
+      </div>
+    )
+  }
+  if (view === 'grid') {
+    return (
+      <ul className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {showNewTile && <CreateSurveyTile />}
+        {items.map((it) => (
+          <SurveyTile
+            key={it.id}
+            item={it}
+            extras={extrasById?.[it.id]}
+          />
+        ))}
+      </ul>
+    )
+  }
+  return (
+    <ul className="space-y-3">
+      {items.map((it) => (
+        <SurveyCard
+          key={it.id}
+          item={it}
+          extras={extrasById?.[it.id]}
+        />
+      ))}
+    </ul>
+  )
+}

--- a/src/components/my-serveys/survey-tile.tsx
+++ b/src/components/my-serveys/survey-tile.tsx
@@ -1,0 +1,80 @@
+import Image from 'next/image'
+import StatusBadge from '@/components/ui/badges'
+import type { SurveyItem, SurveyCardExtras, SurveyStatus } from '@/types/survey'
+
+interface Props {
+  item: SurveyItem
+  extras?: SurveyCardExtras
+}
+
+function formatPeriod(startAt: string, endAt: string | null) {
+  const s = startAt.replaceAll('-', '.')
+  const e = endAt ? endAt.replaceAll('-', '.') : null
+  return e ? `${s} ~ ${e}` : `${s} ~ 종료기간 없음`
+}
+
+export default function SurveyTile({ item, extras }: Props) {
+  const status: SurveyStatus = extras?.status ?? 'ongoing'
+  const period = extras?.period
+  const participants = extras?.participants
+  const pct =
+    participants && participants.target
+      ? Math.min(
+          100,
+          Math.round(
+            (participants.current / Math.max(1, participants.target)) * 100,
+          ),
+        )
+      : 0
+
+  return (
+    <li className="rounded-md border bg-white overflow-hidden">
+      <button className="w-full text-left">
+        {/* 썸네일 영역 */}
+        <div className="relative aspect-[16/9] bg-gray-200">
+          {item.thumbnail && (
+            <Image
+              src={item.thumbnail}
+              alt=""
+              fill
+              className="object-cover"
+            />
+          )}
+          <div className="absolute left-2 top-2">
+            <StatusBadge
+              status={status}
+              widthClass="w-[64px]"
+            />
+          </div>
+        </div>
+
+        {/* 본문 */}
+        <div className="px-3 py-2">
+          <p className="text-sm text-gray-900 leading-snug line-clamp-2 break-words">
+            {item.title}
+          </p>
+
+          {period && (
+            <p className="mt-1 text-[11px] text-gray-600">
+              {formatPeriod(period.startAt, period.endAt)}
+            </p>
+          )}
+
+          {participants && (
+            <>
+              <div className="mt-2 h-2 w-full rounded bg-gray-200 overflow-hidden">
+                <div
+                  className="h-full bg-gray-500"
+                  style={{ width: `${pct}%` }}
+                />
+              </div>
+              <div className="mt-1 text-right text-[11px] text-gray-600">
+                {participants.current}/{participants.target ?? 0}
+              </div>
+            </>
+          )}
+        </div>
+      </button>
+    </li>
+  )
+}

--- a/src/components/my-serveys/survey-tile.tsx
+++ b/src/components/my-serveys/survey-tile.tsx
@@ -28,7 +28,7 @@ export default function SurveyTile({ item, extras }: Props) {
       : 0
 
   return (
-    <li className="rounded-md border bg-white overflow-hidden">
+    <li className="rounded-md border bg-white hover:bg-gray-100 overflow-hidden">
       <button className="w-full text-left">
         {/* 썸네일 영역 */}
         <div className="relative aspect-[16/9] bg-gray-200">

--- a/src/components/my-serveys/toolbar-controls.tsx
+++ b/src/components/my-serveys/toolbar-controls.tsx
@@ -50,6 +50,9 @@ export default function ToolbarControls({
         className={`inline-flex items-center gap-2 rounded-md px-3 py-2 hover:bg-gray-100 ${isGrid ? 'text-gray-900' : 'text-gray-700'}`}
       >
         {/* <Grid2X2 className="size-5" /> */}
+        <span className="hidden whitespace-nowrap sm:inline">
+          {isGrid ? '리스트 보기' : '바둑판 보기'}
+        </span>
       </Link>
 
       {/* 2) 전체 보기 (필터 제거) */}

--- a/src/components/my-serveys/toolbar-controls.tsx
+++ b/src/components/my-serveys/toolbar-controls.tsx
@@ -1,0 +1,72 @@
+import Link from 'next/link'
+// import { Grid2X2 } from 'lucide-react'
+import FilterPopover from '@/components/my-serveys/filter-popover'
+
+interface Props {
+  path: string
+  q?: string
+  view?: 'list' | 'grid'
+  status?: 'ongoing' | 'closed'
+}
+
+function buildHref(
+  path: string,
+  {
+    q,
+    view,
+    status,
+  }: { q?: string; view?: 'list' | 'grid'; status?: 'ongoing' | 'closed' },
+) {
+  const sp = new URLSearchParams()
+  if (q) sp.set('q', q)
+  if (view === 'grid') sp.set('view', 'grid')
+  if (status) sp.set('status', status)
+  const qs = sp.toString()
+  return qs ? `${path}?${qs}` : path
+}
+
+export default function ToolbarControls({
+  path,
+  q,
+  view = 'list',
+  status,
+}: Props) {
+  const isGrid = view === 'grid'
+
+  // Grid 토글
+  const gridHref = isGrid
+    ? buildHref(path, { q, view: 'list', status }) // 다시 리스트로
+    : buildHref(path, { q, view: 'grid', status })
+
+  // 전체 보기 (status 제거)
+  const allHref = buildHref(path, { q, view })
+
+  return (
+    <div className="flex items-center gap-3">
+      {/* 1) 바둑판 보기 토글 */}
+      <Link
+        href={gridHref}
+        aria-label="바둑판 보기 전환"
+        className={`inline-flex items-center gap-2 rounded-md px-3 py-2 hover:bg-gray-100 ${isGrid ? 'text-gray-900' : 'text-gray-700'}`}
+      >
+        {/* <Grid2X2 className="size-5" /> */}
+      </Link>
+
+      {/* 2) 전체 보기 (필터 제거) */}
+      <Link
+        href={allHref}
+        className="inline-flex items-center px-3 py-2 rounded-md hover:bg-gray-100 whitespace-nowrap"
+      >
+        전체 보기
+      </Link>
+
+      {/* 3) 필터 (진행중/종료) */}
+      <FilterPopover
+        path={path}
+        q={q}
+        view={view}
+        status={status}
+      />
+    </div>
+  )
+}

--- a/src/components/ui/badges.tsx
+++ b/src/components/ui/badges.tsx
@@ -1,3 +1,30 @@
+import type { SurveyStatus } from '@/types/survey'
+
+interface Props {
+  status: SurveyStatus
+  widthClass?: string
+}
+
+export default function StatusBadge({
+  status,
+  widthClass = 'w-[70px]',
+}: Props) {
+  const isOngoing = status === 'ongoing'
+  const label = isOngoing ? '진행 중' : '종료'
+  const base = `rounded px-3 py-1 text-xs font-semibold inline-flex items-center justify-center shrink-0 ${widthClass}`
+  return (
+    <span
+      className={
+        isOngoing
+          ? `${base} bg-gray-700 text-white`
+          : `${base} bg-gray-300 text-gray-700`
+      }
+    >
+      {label}
+    </span>
+  )
+}
+
 export function PointBadge({ value }: { value: number }) {
   return (
     <span className="rounded-full bg-white/95 px-3 py-1 text-xs font-semibold text-gray-900 shadow-sm ring-1 ring-gray-200">

--- a/src/components/ui/responsive-slider-grid.tsx
+++ b/src/components/ui/responsive-slider-grid.tsx
@@ -22,7 +22,7 @@ export function ResponsiveSliderGrid({
             [scrollbar-width:none] [-ms-overflow-style:none]
           "
           // 크롬 스크롤바 감추기
-          style={{ scrollbarWidth: 'none' } as any}
+          style={{ scrollbarWidth: 'none' }}
         >
           {items.map((child, i) => (
             <div

--- a/src/components/ui/search-input.tsx
+++ b/src/components/ui/search-input.tsx
@@ -1,0 +1,50 @@
+'use client'
+// import { Search } from 'lucide-react'
+
+interface Props {
+  /** 제출할 경로. 기본값: 현재 경로 */
+  action?: string
+  /** 입력 초기값 (URL의 q 등)을 바인딩) */
+  defaultValue?: string
+  /** 인풋 name (쿼리 파라미터 키) */
+  name?: string
+  placeholder?: string
+  hiddenParams?: Record<string, string | undefined | null>
+}
+
+export default function SearchInput({
+  action = '.',
+  defaultValue = '',
+  name = 'q',
+  placeholder = '내 설문 검색',
+  hiddenParams,
+}: Props) {
+  return (
+    <form
+      action={action}
+      method="GET"
+      role="search"
+      className="relative w-full max-w-md"
+    >
+      {hiddenParams &&
+        Object.entries(hiddenParams).map(([k, v]) =>
+          v ? (
+            <input
+              key={k}
+              type="hidden"
+              name={k}
+              value={v}
+            />
+          ) : null,
+        )}
+      {/* <Search className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-gray-500" /> */}
+      <input
+        name={name}
+        defaultValue={defaultValue}
+        className="w-full pl-9 pr-3 py-2 rounded-md border bg-white text-sm focus:outline-none focus:ring-2 focus:ring-gray-300"
+        placeholder={placeholder}
+        aria-label="내 설문 검색"
+      />
+    </form>
+  )
+}

--- a/src/types/survey.ts
+++ b/src/types/survey.ts
@@ -1,4 +1,7 @@
+// ====== Core domain types ======
 export type RewardType = 'point' | 'gifticon'
+export type SurveyStatus = 'ongoing' | 'closed'
+export type ISODateString = string
 
 export interface SurveyItem {
   id: string
@@ -11,4 +14,53 @@ export interface SurveyItem {
   }
   duration: number // 분 단위
   tags?: string[]
+}
+
+// ====== (목록 카드용 선택 정보) ======
+export interface Period {
+  startAt: ISODateString
+  endAt: ISODateString | null
+}
+export interface ParticipantStats {
+  current: number
+  target: number | null
+}
+
+export interface SurveyCardExtras {
+  /** 설문 상태가 있을 때 뱃지로 노출 */
+  status?: SurveyStatus
+  /** 기간 정보가 있을 때 카드의 보조 텍스트로 노출 */
+  period?: Period
+  /** 참여자 정보가 있을 때 우측 카운터로 노출 */
+  participants?: ParticipantStats
+}
+
+// ====== 조회/페이지네이션/헤더 요약 ======
+export interface SurveyQuery {
+  q?: string
+  status?: SurveyStatus | 'all'
+  rewardType?: RewardType | 'all'
+  tag?: string
+  page?: number
+  pageSize?: number
+  sort?: 'createdAt' | 'duration' | 'title'
+}
+
+export interface PageMeta {
+  total: number
+  page: number
+  pageSize: number
+  hasNext: boolean
+}
+export interface Paged<T> {
+  items: T[]
+  meta: PageMeta
+}
+
+export interface UserSummary {
+  isAuthed: boolean
+  displayName?: string
+  avatarUrl?: string
+  points: number
+  unreadNotifications: number
 }


### PR DESCRIPTION
## 📌 연관된 이슈

> #5

## 🚀 작업 내용

> 헤더 메뉴 구조 임시 수정
내 설문 목록 페이지 기초 퍼블리싱 작업
컴파일 오류 해결

## ✅ 변경 사항 체크리스트

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
> 예시: 이 부분의 코드가 잘 작동하는지 테스트해 주실 수 있나요?

## 📢 노트 (선택)

> 헤더 메뉴 구조 이미지
<img width="1117" height="124" alt="스크린샷 2025-08-29 오후 3 10 47" src="https://github.com/user-attachments/assets/91db66f2-e4cb-4f96-840a-efdc260b38a6" />

- 오른쪽 상단 메뉴는 순서대로 포인트 / 등급(아이콘 미설정) / 알림(아이콘 미설정) / 내 프로필 입니다
- 내정보 클릭 시 우측에서 사이드바가 나타나며
- 로그인 상태에 따라 생성되는 버튼이 달라집니다
- 현재 로그인 상태는 하드코딩된 상태이며 header.tsx 의 isAuthed 속성 변경을 통해 확인 가능합니다

> 내 설문 목록 페이지 퍼블리싱 이미지
<img width="1107" height="585" alt="스크린샷 2025-08-29 오후 3 12 24" src="https://github.com/user-attachments/assets/3d83ef96-d5bf-48e5-a975-50092d9bf726" />
<img width="1111" height="521" alt="스크린샷 2025-08-29 오후 3 14 55" src="https://github.com/user-attachments/assets/2a58b4d7-82ac-4b37-9d8a-157ee4c09840" />

- 이미지는 리스트 보기 / 바둑판 보기 상태순 입니다
- 필터 클릭 시 진행중 / 종료 상태 설문을 필터링 할 수 있습니다
- 전체보기 클릭 시 필터링이 해제가 됩니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 내 설문 목록 페이지 추가: 검색(q), 상태 필터(진행/종료), 리스트/그리드 전환, 빈 상태 메시지, 새 설문 만들기 카드/타일 제공
  - 헤더에 프로필 패널 추가(로그인/로그아웃, 마이페이지 이동), 알림 표시, 포인트 표시
  - 설문 상태 배지 및 카드/타일 UI 도입
- Refactor
  - 헤더 내비게이션 재구성(중앙 메뉴, 활성 상태 표시, 접근성 개선), 링크 경로 정비(/my-surveys, /my-page, /reward-shop, /notifications)
  - 홈 광고 슬라이더 자동재생/이전·다음 동작 안정화 및 호버 일시정지 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->