### PR TITLE
[FEAT] 설문조사 진행 페이지 및 완료 페이지 구현

### DIFF
--- a/src/app/surveys/[id]/complete/components/gift-completion-page.tsx
+++ b/src/app/surveys/[id]/complete/components/gift-completion-page.tsx
@@ -1,0 +1,142 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { CheckIcon } from '@/components/icons'
+import Image from 'next/image'
+
+interface GiftCompletionPageProps {
+  productName: string
+  productImage?: string
+  raffleDate: {
+    year: string
+    month: string
+    day: string
+  }
+  winnerCount: number
+  surveyTitle: string
+}
+
+export default function GiftCompletionPage({ 
+  productName,
+  productImage = '/images/sample-1.png',
+  raffleDate,
+  winnerCount,
+  surveyTitle
+}: GiftCompletionPageProps) {
+  const router = useRouter()
+
+  return (
+    <div className="min-h-screen bg-[#f9f9f9]">
+      {/* Header */}
+      <div className="bg-white border-b border-[#c9cbd1]">
+        <div className="max-w-7xl mx-auto px-5 py-4">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-4">
+              <button
+                onClick={() => router.push('/surveys')}
+                className="text-[#434447] hover:text-[#0db2a4] transition-colors"
+              >
+                ← 설문 목록으로 돌아가기
+              </button>
+            </div>
+            <div className="text-center">
+              <h1 className="text-[22px] font-semibold text-[#434447]">설문 완료</h1>
+            </div>
+            <div className="w-32"></div>
+          </div>
+        </div>
+      </div>
+
+      {/* Main Content */}
+      <div className="max-w-2xl mx-auto px-5 py-12">
+        <div className="flex flex-col items-center gap-12">
+          {/* Success Icon and Message */}
+          <div className="flex flex-col items-center gap-6">
+            <div className="bg-[#5ed7c3] rounded-full p-1 w-12 h-12 flex items-center justify-center">
+              <CheckIcon className="w-9 h-9 text-white" />
+            </div>
+            <div className="text-center">
+              <h2 className="text-[26px] font-semibold text-[#434447] tracking-[-0.72px] leading-[36px] mb-1.5">
+                설문에 참여해주셔서 감사합니다
+              </h2>
+              <p className="text-[#91959c] text-[16px] leading-[22px]">
+                해당 리워드 추첨은 설문조사 종료 후 제공되며, 추후 알림창을 통해 추첨을 확인하실 수 있습니다
+              </p>
+            </div>
+          </div>
+
+          {/* Gift Info Card */}
+          <div className="bg-white border-2 border-[#5ed7c3] rounded-[16px] p-6 w-full">
+            <div className="flex gap-2 items-center">
+              {/* Product Image */}
+              <div className="w-[120px] h-[120px] rounded-[8px] overflow-hidden bg-gray-100 flex-shrink-0">
+                <Image
+                  src={productImage}
+                  alt={productName}
+                  width={120}
+                  height={120}
+                  className="w-full h-full object-cover"
+                />
+              </div>
+              
+              {/* Product Info */}
+              <div className="flex-1 px-2 py-3">
+                <h3 className="text-[#434447] text-[18px] font-medium leading-[26px] tracking-[-0.48px] mb-4 line-clamp-2">
+                  {productName}
+                </h3>
+                
+                <div className="space-y-1">
+                  {/* Raffle Date */}
+                  <div className="flex items-center gap-2">
+                    <span className="text-[#434447] text-[16px] font-medium">추첨 예상 날짜</span>
+                    <div className="flex items-center gap-1">
+                      <span className="text-[#91959c] text-[16px]">{raffleDate.year}년</span>
+                      <span className="text-[#91959c] text-[16px]">{raffleDate.month}월</span>
+                      <span className="text-[#91959c] text-[16px]">{raffleDate.day}일</span>
+                    </div>
+                  </div>
+                  
+                  {/* Winner Count */}
+                  <div className="flex items-center gap-2">
+                    <span className="text-[#434447] text-[16px] font-medium">당첨자 수</span>
+                    <span className="text-[#91959c] text-[16px]">{winnerCount}명</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Action Button */}
+          <button
+            onClick={() => router.push('/surveys')}
+            className="bg-[#5ed7c3] text-[#434447] py-4 px-16 rounded-[8px] font-medium text-[20px] leading-[28px] hover:bg-[#4bc4b0] transition-colors"
+          >
+            다른 설문 조사 참여하러 가기
+          </button>
+        </div>
+      </div>
+
+      {/* Footer */}
+      <div className="bg-[#f9f9f9] border-t border-[#e8e9eb] mt-auto">
+        <div className="max-w-7xl mx-auto px-5 py-8">
+          <div className="flex flex-col items-center gap-4">
+            <div className="flex gap-6 items-center">
+              <span className="text-[#91959c] text-[16px] font-medium">이용약관</span>
+              <div className="w-px h-[22px] bg-[#c9cbd1]"></div>
+              <span className="text-[#91959c] text-[16px] font-medium">개인정보보호정책</span>
+              <div className="w-px h-[22px] bg-[#c9cbd1]"></div>
+              <span className="text-[#91959c] text-[16px] font-medium">고객센터</span>
+            </div>
+            <div className="text-center text-[#91959c] text-[12px] leading-[16px] tracking-[-0.64px]">
+              <p>Copyright© Pollet All right reserved.</p>
+              <p className="mt-1">
+                상호명 (주)폴렛 | 대표 장우영 | 개인정보보호책임자 이승훈 | 사업자등록번호 025-09-02153<br />
+                주소 경기도 성남시 분당구 판교로 242 PDC A동 902호
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/surveys/[id]/complete/components/points-completion-page.tsx
+++ b/src/app/surveys/[id]/complete/components/points-completion-page.tsx
@@ -1,0 +1,107 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { CheckIcon, StarcandyIcon } from '@/components/icons'
+
+interface PointsCompletionPageProps {
+  earnedPoints: number
+  surveyTitle: string
+}
+
+export default function PointsCompletionPage({ 
+  earnedPoints, 
+  surveyTitle 
+}: PointsCompletionPageProps) {
+  const router = useRouter()
+
+  return (
+    <div className="min-h-screen bg-[#f9f9f9]">
+      {/* Header */}
+      <div className="bg-white border-b border-[#c9cbd1]">
+        <div className="max-w-7xl mx-auto px-5 py-4">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-4">
+              <button
+                onClick={() => router.push('/surveys')}
+                className="text-[#434447] hover:text-[#0db2a4] transition-colors"
+              >
+                ← 설문 목록으로 돌아가기
+              </button>
+            </div>
+            <div className="text-center">
+              <h1 className="text-[22px] font-semibold text-[#434447]">설문 완료</h1>
+            </div>
+            <div className="w-32"></div>
+          </div>
+        </div>
+      </div>
+
+      {/* Main Content */}
+      <div className="max-w-2xl mx-auto px-5 py-12">
+        <div className="flex flex-col items-center gap-12">
+          {/* Success Icon and Message */}
+          <div className="flex flex-col items-center gap-6">
+            <div className="bg-[#5ed7c3] rounded-full p-1 w-12 h-12 flex items-center justify-center">
+              <CheckIcon className="w-9 h-9 text-white" />
+            </div>
+            <div className="text-center">
+              <h2 className="text-[26px] font-semibold text-[#434447] tracking-[-0.72px] leading-[36px] mb-1.5">
+                설문에 참여해주셔서 감사합니다
+              </h2>
+              <p className="text-[#91959c] text-[16px] leading-[22px]">
+                보상은 즉시 적립되며, 자세한 내역은 마이페이지에서 확인하실 수 있습니다
+              </p>
+            </div>
+          </div>
+
+          {/* Points Earned Card */}
+          <div className="bg-white border-2 border-[#5ed7c3] rounded-[16px] p-6 w-full max-w-[588px]">
+            <div className="flex items-center justify-center">
+              <div className="flex flex-col items-center gap-1">
+                <p className="text-[#434447] text-[16px] font-medium text-center">
+                  획득 포인트
+                </p>
+                <div className="flex items-center gap-1">
+                  <StarcandyIcon className="w-6 h-6 text-[#0db2a4]" />
+                  <span className="text-[#0db2a4] text-[24px] font-bold tracking-[-0.72px] leading-[32px]">
+                    {earnedPoints.toLocaleString()}
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Action Button */}
+          <button
+            onClick={() => router.push('/surveys')}
+            className="bg-[#5ed7c3] text-[#434447] py-4 px-16 rounded-[8px] font-medium text-[20px] leading-[28px] hover:bg-[#4bc4b0] transition-colors"
+          >
+            다른 설문 조사 참여하러 가기
+          </button>
+        </div>
+      </div>
+
+      {/* Footer */}
+      <div className="bg-[#f9f9f9] border-t border-[#e8e9eb] mt-auto">
+        <div className="max-w-7xl mx-auto px-5 py-8">
+          <div className="flex flex-col items-center gap-4">
+            <div className="flex gap-6 items-center">
+              <span className="text-[#91959c] text-[16px] font-medium">이용약관</span>
+              <div className="w-px h-[22px] bg-[#c9cbd1]"></div>
+              <span className="text-[#91959c] text-[16px] font-medium">개인정보보호정책</span>
+              <div className="w-px h-[22px] bg-[#c9cbd1]"></div>
+              <span className="text-[#91959c] text-[16px] font-medium">고객센터</span>
+            </div>
+            <div className="text-center text-[#91959c] text-[12px] leading-[16px] tracking-[-0.64px]">
+              <p>Copyright© Pollet All right reserved.</p>
+              <p className="mt-1">
+                상호명 (주)폴렛 | 대표 장우영 | 개인정보보호책임자 이승훈 | 사업자등록번호 025-09-02153<br />
+                주소 경기도 성남시 분당구 판교로 242 PDC A동 902호
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/surveys/[id]/complete/page.tsx
+++ b/src/app/surveys/[id]/complete/page.tsx
@@ -1,0 +1,87 @@
+'use client'
+
+import { useParams, useSearchParams } from 'next/navigation'
+import { useEffect, useState } from 'react'
+import { fetchSurveyById } from '@/lib/fetch-survey'
+import { Survey } from '@/types/survey'
+import PointsCompletionPage from './components/points-completion-page'
+import GiftCompletionPage from './components/gift-completion-page'
+
+export default function SurveyCompletePage() {
+  const params = useParams()
+  const searchParams = useSearchParams()
+  const [survey, setSurvey] = useState<Survey | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  // URL 파라미터에서 보상 타입과 정보 가져오기
+  const rewardType = searchParams.get('type') // 'points' 또는 'gift'
+  const earnedPoints = parseInt(searchParams.get('points') || '0')
+  const productName = searchParams.get('productName') || ''
+  const raffleYear = searchParams.get('raffleYear') || '2024'
+  const raffleMonth = searchParams.get('raffleMonth') || '12'
+  const raffleDay = searchParams.get('raffleDay') || '31'
+  const winnerCount = parseInt(searchParams.get('winnerCount') || '1')
+
+  useEffect(() => {
+    const loadSurvey = async () => {
+      try {
+        const surveyData = await fetchSurveyById(params.id as string)
+        setSurvey(surveyData)
+      } catch (error) {
+        console.error('Failed to load survey:', error)
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    if (params.id) {
+      loadSurvey()
+    }
+  }, [params.id])
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-[#f9f9f9] flex items-center justify-center">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-[#5ed7c3] mx-auto mb-4"></div>
+          <p className="text-[#434447]">완료 정보를 불러오는 중...</p>
+        </div>
+      </div>
+    )
+  }
+
+  if (!survey) {
+    return (
+      <div className="min-h-screen bg-[#f9f9f9] flex items-center justify-center">
+        <div className="text-center">
+          <p className="text-[#434447] text-xl">설문 정보를 찾을 수 없습니다.</p>
+        </div>
+      </div>
+    )
+  }
+
+  // 보상 타입에 따라 다른 페이지 렌더링
+  if (rewardType === 'points') {
+    return (
+      <PointsCompletionPage
+        earnedPoints={earnedPoints}
+        surveyTitle={survey.title}
+      />
+    )
+  }
+
+  // 기본값은 기프티콘 보상 페이지
+  return (
+    <GiftCompletionPage
+      productName={productName || survey.title}
+      productImage="/images/sample-1.png"
+      raffleDate={{
+        year: raffleYear,
+        month: raffleMonth,
+        day: raffleDay
+      }}
+      winnerCount={winnerCount}
+      surveyTitle={survey.title}
+    />
+  )
+}

--- a/src/app/surveys/[id]/start/components/interview-request-modal.tsx
+++ b/src/app/surveys/[id]/start/components/interview-request-modal.tsx
@@ -1,0 +1,91 @@
+'use client'
+
+interface InterviewRequestModalProps {
+  isOpen: boolean
+  onClose: () => void
+  onAccept: () => void
+  userName?: string
+  duration?: string
+  reward?: string
+}
+
+export default function InterviewRequestModal({ 
+  isOpen, 
+  onClose, 
+  onAccept,
+  userName = "과제울렁증극복하기",
+  duration = "1시간 30분",
+  reward = "배달의 민족 2만원 기프티콘"
+}: InterviewRequestModalProps) {
+  if (!isOpen) return null
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="bg-white box-border content-stretch flex flex-col gap-6 items-center justify-center pb-6 pt-8 px-6 relative rounded-[32px] w-full max-w-md">
+        <div className="font-['Pretendard_Variable:Bold',_sans-serif] leading-[0] not-italic relative shrink-0 text-[#292a2c] text-[22px] text-nowrap">
+          <p className="leading-[30px] whitespace-pre">인터뷰 요청을 수락하시겠습니까?</p>
+        </div>
+        
+        <div className="content-center flex flex-wrap gap-0 items-center justify-center leading-[0] not-italic relative shrink-0 text-[#434447] text-[16px] text-nowrap tracking-[-0.4px] w-full">
+          <div className="font-['Pretendard_Variable:Bold',_sans-serif] relative shrink-0">
+            <p className="leading-[28px] text-nowrap whitespace-pre">{userName}</p>
+          </div>
+          <div className="font-['Pretendard_Variable:Medium',_sans-serif] relative shrink-0">
+            <p className="leading-[28px] text-nowrap whitespace-pre">{`님은 인터뷰 대상자입니다. `}</p>
+          </div>
+          <div className="font-['Pretendard_Variable:Medium',_sans-serif] relative shrink-0">
+            <p className="leading-[28px] text-nowrap whitespace-pre">인터뷰 요청 수락 시 추가 리워드를 획득할 수 있습니다.</p>
+          </div>
+        </div>
+        
+        <div className="content-stretch flex flex-col gap-1 items-start justify-start relative shrink-0 w-full">
+          <div className="content-center flex flex-wrap gap-1.5 items-center justify-center relative shrink-0 w-full">
+            <div className="font-['Pretendard_Variable:Bold',_sans-serif] leading-[0] not-italic relative shrink-0 text-[#434447] text-[16px] text-nowrap tracking-[-0.4px]">
+              <p className="leading-[28px] whitespace-pre">인터뷰 소요 시간</p>
+            </div>
+            <div className="content-stretch flex gap-0.5 items-center justify-start relative shrink-0">
+              <div className="font-['Pretendard_Variable:Medium',_sans-serif] leading-[0] not-italic relative shrink-0 text-[#0db2a4] text-[16px] text-nowrap tracking-[-0.4px]">
+                <p className="leading-[28px] text-nowrap whitespace-pre">약</p>
+              </div>
+              <div className="content-stretch flex font-['Pretendard_Variable:Medium',_sans-serif] items-center justify-start leading-[0] not-italic relative shrink-0 text-[#0db2a4] text-[16px] text-nowrap tracking-[-0.4px]">
+                <div className="relative shrink-0">
+                  <p className="leading-[28px] text-nowrap whitespace-pre">{duration}</p>
+                </div>
+              </div>
+            </div>
+          </div>
+          
+          <div className="content-center flex flex-wrap gap-1.5 items-center justify-center relative shrink-0 w-full">
+            <div className="font-['Pretendard_Variable:Bold',_sans-serif] leading-[0] not-italic relative shrink-0 text-[#434447] text-[16px] text-nowrap tracking-[-0.4px]">
+              <p className="leading-[28px] whitespace-pre">참여 보상</p>
+            </div>
+            <div className="content-stretch flex gap-0.5 items-center justify-start relative shrink-0">
+              <div className="font-['Pretendard_Variable:Medium',_sans-serif] leading-[0] not-italic relative shrink-0 text-[#0db2a4] text-[16px] text-nowrap tracking-[-0.4px]">
+                <p className="leading-[28px] text-nowrap whitespace-pre">{reward}</p>
+              </div>
+            </div>
+          </div>
+        </div>
+        
+        <div className="content-stretch flex gap-3 items-center justify-start relative shrink-0 w-full">
+          <button
+            onClick={onClose}
+            className="basis-0 bg-[#e8e9eb] box-border content-stretch flex gap-3 grow items-center justify-center min-h-px min-w-px px-4 py-3 relative rounded-[8px] shrink-0"
+          >
+            <div className="font-['Pretendard_Variable:Medium',_sans-serif] leading-[0] not-italic relative shrink-0 text-[#434447] text-[20px] text-nowrap">
+              <p className="leading-[28px] whitespace-pre">설문 종료</p>
+            </div>
+          </button>
+          <button
+            onClick={onAccept}
+            className="basis-0 bg-[#5ed7c3] box-border content-stretch flex gap-3 grow items-center justify-center min-h-px min-w-px px-4 py-3 relative rounded-[8px] shrink-0"
+          >
+            <div className="font-['Pretendard_Variable:Medium',_sans-serif] leading-[0] not-italic relative shrink-0 text-[#434447] text-[20px] text-nowrap">
+              <p className="leading-[28px] whitespace-pre">인터뷰 수락</p>
+            </div>
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/surveys/[id]/start/components/privacy-consent-modal.tsx
+++ b/src/app/surveys/[id]/start/components/privacy-consent-modal.tsx
@@ -1,0 +1,102 @@
+'use client'
+
+interface PrivacyConsentModalProps {
+  isOpen: boolean
+  onClose: () => void
+  onAgree: () => void
+}
+
+export default function PrivacyConsentModal({ 
+  isOpen, 
+  onClose, 
+  onAgree 
+}: PrivacyConsentModalProps) {
+  if (!isOpen) return null
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="bg-white box-border content-stretch flex flex-col gap-6 items-start justify-start pb-6 pt-8 px-6 relative rounded-[32px] w-full max-w-md">
+        <div className="font-['Pretendard_Variable:Bold',_sans-serif] leading-[0] not-italic relative shrink-0 text-[#292a2c] text-[22px] w-full">
+          <p className="leading-[30px]">개인정보 동의 수집 및 이용 동의</p>
+        </div>
+        
+        <div className="content-stretch flex flex-col gap-2 items-start justify-start relative shrink-0 w-full">
+          <div className="content-stretch flex gap-3 items-center justify-start leading-[0] not-italic relative shrink-0 text-[16px] text-nowrap tracking-[-0.4px] w-full">
+            <div className="font-['Pretendard_Variable:Bold',_sans-serif] relative shrink-0 text-[#434447]">
+              <p className="leading-[28px] text-nowrap whitespace-pre">개인정보 수집 목적</p>
+            </div>
+            <div className="font-['Pretendard_Variable:Medium',_sans-serif] relative shrink-0 text-[#0db2a4]">
+              <p className="leading-[28px] text-nowrap whitespace-pre">기프티콘 전달</p>
+            </div>
+          </div>
+          
+          <div className="content-stretch flex gap-3 items-start justify-start relative shrink-0 w-full">
+            <div className="font-['Pretendard_Variable:Bold',_sans-serif] leading-[0] not-italic relative shrink-0 text-[#434447] text-[16px] text-nowrap tracking-[-0.4px]">
+              <p className="leading-[28px] whitespace-pre">개인정보 수집 항목</p>
+            </div>
+            <div className="basis-0 content-center flex flex-wrap font-['Pretendard_Variable:Medium',_sans-serif] gap-1 grow items-center justify-start leading-[0] min-h-px min-w-px not-italic relative shrink-0 text-[#0db2a4] text-[16px] text-nowrap tracking-[-0.4px]">
+              <div className="content-stretch flex items-center justify-start relative shrink-0">
+                <div className="relative shrink-0">
+                  <p className="leading-[28px] text-nowrap whitespace-pre">연락처</p>
+                </div>
+                <div className="relative shrink-0">
+                  <p className="leading-[28px] text-nowrap whitespace-pre">,</p>
+                </div>
+              </div>
+              <div className="content-stretch flex items-center justify-start relative shrink-0">
+                <div className="relative shrink-0">
+                  <p className="leading-[28px] text-nowrap whitespace-pre">이메일</p>
+                </div>
+                <div className="relative shrink-0">
+                  <p className="leading-[28px] text-nowrap whitespace-pre">,</p>
+                </div>
+              </div>
+              <div className="content-stretch flex items-center justify-start relative shrink-0">
+                <div className="relative shrink-0">
+                  <p className="leading-[28px] text-nowrap whitespace-pre">이름</p>
+                </div>
+                <div className="relative shrink-0">
+                  <p className="leading-[28px] text-nowrap whitespace-pre">,</p>
+                </div>
+              </div>
+              <div className="relative shrink-0">
+                <p className="leading-[28px] text-nowrap whitespace-pre">직접 입력</p>
+              </div>
+              <div className="relative shrink-0">
+                <p className="leading-[28px] text-nowrap whitespace-pre">직접 입력 내용이 길어질 경우</p>
+              </div>
+            </div>
+          </div>
+          
+          <div className="content-stretch flex gap-3 items-center justify-start leading-[0] not-italic relative shrink-0 text-[16px] text-nowrap tracking-[-0.4px] w-full">
+            <div className="font-['Pretendard_Variable:Bold',_sans-serif] relative shrink-0 text-[#434447]">
+              <p className="leading-[28px] text-nowrap whitespace-pre">개인정보 보유 및 이용 기간</p>
+            </div>
+            <div className="font-['Pretendard_Variable:Medium',_sans-serif] relative shrink-0 text-[#0db2a4]">
+              <p className="leading-[28px] text-nowrap whitespace-pre">3개월</p>
+            </div>
+          </div>
+        </div>
+        
+        <div className="content-stretch flex gap-3 items-center justify-start relative shrink-0 w-full">
+          <button
+            onClick={onClose}
+            className="basis-0 bg-[#e8e9eb] box-border content-stretch flex gap-3 grow items-center justify-center min-h-px min-w-px px-4 py-3 relative rounded-[8px] shrink-0"
+          >
+            <div className="font-['Pretendard_Variable:Medium',_sans-serif] leading-[0] not-italic relative shrink-0 text-[#434447] text-[20px] text-nowrap">
+              <p className="leading-[28px] whitespace-pre">취소</p>
+            </div>
+          </button>
+          <button
+            onClick={onAgree}
+            className="basis-0 bg-[#5ed7c3] box-border content-stretch flex gap-3 grow items-center justify-center min-h-px min-w-px px-4 py-3 relative rounded-[8px] shrink-0"
+          >
+            <div className="font-['Pretendard_Variable:Medium',_sans-serif] leading-[0] not-italic relative shrink-0 text-[#434447] text-[20px] text-nowrap">
+              <p className="leading-[28px] whitespace-pre">동의 후 설문 시작</p>
+            </div>
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/surveys/[id]/start/components/progress-bar.tsx
+++ b/src/app/surveys/[id]/start/components/progress-bar.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+interface ProgressBarProps {
+  current: number
+  total: number
+  className?: string
+}
+
+export default function ProgressBar({ 
+  current, 
+  total, 
+  className = "" 
+}: ProgressBarProps) {
+  const percentage = total > 0 ? (current / total) * 100 : 0
+
+  return (
+    <div className={`relative size-full ${className}`}>
+      <div className="absolute content-stretch flex flex-col gap-1 h-3 items-start justify-start left-0 top-0 w-full">
+        <div className="absolute bg-[#e8e9eb] h-3 left-0 rounded-[16px] top-0 w-full" />
+        <div 
+          className="bg-[#5ed7c3] h-3 rounded-[16px] shrink-0 transition-all duration-300 ease-in-out"
+          style={{ width: `${percentage}%` }}
+        />
+      </div>
+      <div className="absolute box-border content-stretch flex gap-0.5 items-center justify-start left-1/2 px-4 py-1 rounded-[32px] top-4 -translate-x-1/2">
+        <div aria-hidden="true" className="absolute border-[#c9cbd1] border-[1.8px] border-solid inset-0 pointer-events-none rounded-[32px]" />
+        <div className="font-['Pretendard_Variable:SemiBold',_sans-serif] leading-[0] not-italic relative shrink-0 text-[#434447] text-[18px] text-nowrap tracking-[-0.48px]">
+          <p className="leading-[26px] whitespace-pre">{current}</p>
+        </div>
+        <div className="font-['Pretendard_Variable:Medium',_sans-serif] leading-[0] not-italic relative shrink-0 text-[#91959c] text-[16px] text-nowrap">
+          <p className="leading-[22px] whitespace-pre">/</p>
+        </div>
+        <div className="font-['Pretendard_Variable:Medium',_sans-serif] leading-[0] not-italic relative shrink-0 text-[#91959c] text-[16px] text-nowrap">
+          <p className="leading-[22px] whitespace-pre">{total}</p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/surveys/[id]/start/components/third-party-consent-modal.tsx
+++ b/src/app/surveys/[id]/start/components/third-party-consent-modal.tsx
@@ -1,0 +1,99 @@
+'use client'
+
+interface ThirdPartyConsentModalProps {
+  isOpen: boolean
+  onClose: () => void
+  onAgree: () => void
+}
+
+export default function ThirdPartyConsentModal({ 
+  isOpen, 
+  onClose, 
+  onAgree 
+}: ThirdPartyConsentModalProps) {
+  if (!isOpen) return null
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="bg-white box-border content-stretch flex flex-col gap-6 items-start justify-start pb-6 pt-8 px-6 relative rounded-[32px] w-full max-w-md">
+        <div className="font-['Pretendard_Variable:Bold',_sans-serif] leading-[0] not-italic relative shrink-0 text-[#292a2c] text-[22px] w-full">
+          <p className="leading-[30px]">개인정보 제3자 동의</p>
+        </div>
+        
+        <div className="content-stretch flex flex-col gap-2 items-start justify-start relative shrink-0 w-full">
+          <div className="content-stretch flex gap-3 items-center justify-start leading-[0] not-italic relative shrink-0 text-[16px] text-nowrap tracking-[-0.4px] w-full">
+            <div className="font-['Pretendard_Variable:Bold',_sans-serif] relative shrink-0 text-[#434447]">
+              <p className="leading-[28px] text-nowrap whitespace-pre">개인정보 수집 목적</p>
+            </div>
+            <div className="font-['Pretendard_Variable:Medium',_sans-serif] relative shrink-0 text-[#0db2a4]">
+              <p className="leading-[28px] text-nowrap whitespace-pre">기프티콘 전달</p>
+            </div>
+          </div>
+          
+          <div className="content-stretch flex gap-3 items-start justify-start relative shrink-0 w-full">
+            <div className="font-['Pretendard_Variable:Bold',_sans-serif] leading-[0] not-italic relative shrink-0 text-[#434447] text-[16px] text-nowrap tracking-[-0.4px]">
+              <p className="leading-[28px] whitespace-pre">개인정보 수집 항목</p>
+            </div>
+            <div className="basis-0 content-stretch flex font-['Pretendard_Variable:Medium',_sans-serif] gap-1 grow items-center justify-start leading-[0] min-h-px min-w-px not-italic relative shrink-0 text-[#0db2a4] text-[16px] text-nowrap tracking-[-0.4px]">
+              <div className="content-stretch flex items-center justify-start relative shrink-0">
+                <div className="relative shrink-0">
+                  <p className="leading-[28px] text-nowrap whitespace-pre">연락처</p>
+                </div>
+                <div className="relative shrink-0">
+                  <p className="leading-[28px] text-nowrap whitespace-pre">,</p>
+                </div>
+              </div>
+              <div className="content-stretch flex items-center justify-start relative shrink-0">
+                <div className="relative shrink-0">
+                  <p className="leading-[28px] text-nowrap whitespace-pre">이메일</p>
+                </div>
+                <div className="relative shrink-0">
+                  <p className="leading-[28px] text-nowrap whitespace-pre">,</p>
+                </div>
+              </div>
+              <div className="content-stretch flex items-center justify-start relative shrink-0">
+                <div className="relative shrink-0">
+                  <p className="leading-[28px] text-nowrap whitespace-pre">이름</p>
+                </div>
+                <div className="relative shrink-0">
+                  <p className="leading-[28px] text-nowrap whitespace-pre">,</p>
+                </div>
+              </div>
+              <div className="relative shrink-0">
+                <p className="leading-[28px] text-nowrap whitespace-pre">직접 입력</p>
+              </div>
+            </div>
+          </div>
+          
+          <div className="content-stretch flex gap-3 items-center justify-start leading-[0] not-italic relative shrink-0 text-[16px] text-nowrap tracking-[-0.4px] w-full">
+            <div className="font-['Pretendard_Variable:Bold',_sans-serif] relative shrink-0 text-[#434447]">
+              <p className="leading-[28px] text-nowrap whitespace-pre">개인정보 보유 및 이용 기간</p>
+            </div>
+            <div className="font-['Pretendard_Variable:Medium',_sans-serif] relative shrink-0 text-[#0db2a4]">
+              <p className="leading-[28px] text-nowrap whitespace-pre">3개월</p>
+            </div>
+          </div>
+        </div>
+        
+        <div className="content-stretch flex gap-3 items-center justify-start relative shrink-0 w-full">
+          <button
+            onClick={onClose}
+            className="basis-0 bg-[#e8e9eb] box-border content-stretch flex gap-3 grow items-center justify-center min-h-px min-w-px px-4 py-3 relative rounded-[8px] shrink-0"
+          >
+            <div className="font-['Pretendard_Variable:Medium',_sans-serif] leading-[0] not-italic relative shrink-0 text-[#434447] text-[20px] text-nowrap">
+              <p className="leading-[28px] whitespace-pre">취소</p>
+            </div>
+          </button>
+          <button
+            onClick={onAgree}
+            className="basis-0 bg-[#5ed7c3] box-border content-stretch flex gap-3 grow items-center justify-center min-h-px min-w-px px-4 py-3 relative rounded-[8px] shrink-0"
+          >
+            <div className="font-['Pretendard_Variable:Medium',_sans-serif] leading-[0] not-italic relative shrink-0 text-[#434447] text-[20px] text-nowrap">
+              <p className="leading-[28px] whitespace-pre">동의 후 설문 시작</p>
+            </div>
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/surveys/[id]/start/page.tsx
+++ b/src/app/surveys/[id]/start/page.tsx
@@ -1,0 +1,289 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { useParams, useRouter } from 'next/navigation'
+import { fetchSurveyById } from '@/lib/fetch-survey'
+import { Survey } from '@/types/survey'
+import ProgressBar from './components/progress-bar'
+import PrivacyConsentModal from './components/privacy-consent-modal'
+import ThirdPartyConsentModal from './components/third-party-consent-modal'
+import InterviewRequestModal from './components/interview-request-modal'
+
+type ModalType = 'privacy' | 'thirdParty' | 'interview' | null
+
+export default function SurveyStartPage() {
+  const params = useParams()
+  const router = useRouter()
+  const [survey, setSurvey] = useState<Survey | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [currentModal, setCurrentModal] = useState<ModalType>('privacy')
+  const [currentQuestion, setCurrentQuestion] = useState(0)
+  const [answers, setAnswers] = useState<Record<number, any>>({})
+
+  // 모달 순서: privacy -> thirdParty -> interview -> survey
+  const modalSequence: ModalType[] = ['privacy', 'thirdParty', 'interview', null]
+
+  useEffect(() => {
+    const loadSurvey = async () => {
+      try {
+        const surveyData = await fetchSurveyById(params.id as string)
+        setSurvey(surveyData)
+      } catch (error) {
+        console.error('Failed to load survey:', error)
+        router.push('/surveys')
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    if (params.id) {
+      loadSurvey()
+    }
+  }, [params.id, router])
+
+  const handleModalAction = (action: 'close' | 'agree' | 'accept') => {
+    const currentIndex = modalSequence.indexOf(currentModal)
+    
+    if (action === 'close') {
+      router.push(`/surveys/${params.id}`)
+      return
+    }
+
+    if (action === 'agree' || action === 'accept') {
+      if (currentIndex < modalSequence.length - 1) {
+        setCurrentModal(modalSequence[currentIndex + 1])
+      } else {
+        setCurrentModal(null) // 모든 모달 완료, 설문 시작
+      }
+    }
+  }
+
+  const handleAnswer = (questionIndex: number, answer: any) => {
+    setAnswers(prev => ({
+      ...prev,
+      [questionIndex]: answer
+    }))
+  }
+
+  const handleNext = () => {
+    // TODO: 실제 설문 로직 구현
+    if (currentQuestion < 2) { // 임시로 3개 질문
+      setCurrentQuestion(prev => prev + 1)
+    } else {
+      // 설문 완료 - 보상 타입에 따라 다른 완료 페이지로 이동
+      const rewardType = survey?.reward.type
+      
+      if (rewardType === 'point') {
+        // 포인트 보상 완료 페이지
+        router.push(`/surveys/${params.id}/complete?type=points&points=${survey?.reward.value || 0}`)
+      } else {
+        // 기프티콘 보상 완료 페이지 (추첨)
+        const raffleDate = new Date()
+        raffleDate.setDate(raffleDate.getDate() + 7) // 7일 후 추첨
+        
+        router.push(`/surveys/${params.id}/complete?type=gift&productName=${encodeURIComponent(survey?.title || '')}&raffleYear=${raffleDate.getFullYear()}&raffleMonth=${String(raffleDate.getMonth() + 1).padStart(2, '0')}&raffleDay=${String(raffleDate.getDate()).padStart(2, '0')}&winnerCount=10`)
+      }
+    }
+  }
+
+  const handlePrevious = () => {
+    if (currentQuestion > 0) {
+      setCurrentQuestion(prev => prev - 1)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-[#f9f9f9] flex items-center justify-center">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-[#5ed7c3] mx-auto mb-4"></div>
+          <p className="text-[#434447]">설문을 불러오는 중...</p>
+        </div>
+      </div>
+    )
+  }
+
+  if (!survey) {
+    return (
+      <div className="min-h-screen bg-[#f9f9f9] flex items-center justify-center">
+        <div className="text-center">
+          <p className="text-[#434447] text-xl">설문을 찾을 수 없습니다.</p>
+          <button 
+            onClick={() => router.push('/surveys')}
+            className="mt-4 px-6 py-2 bg-[#5ed7c3] text-white rounded-lg hover:bg-[#4bc4b0] transition-colors"
+          >
+            설문 목록으로 돌아가기
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-[#f9f9f9]">
+      {/* Header */}
+      <div className="bg-white border-b border-[#c9cbd1]">
+        <div className="max-w-7xl mx-auto px-5 py-4">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-4">
+              <button
+                onClick={() => router.push(`/surveys/${params.id}`)}
+                className="text-[#434447] hover:text-[#0db2a4] transition-colors"
+              >
+                ← 설문 상세로 돌아가기
+              </button>
+            </div>
+            <div className="text-center">
+              <h1 className="text-[22px] font-semibold text-[#434447]">{survey.title}</h1>
+            </div>
+            <div className="w-32"></div> {/* 균형을 위한 빈 공간 */}
+          </div>
+        </div>
+      </div>
+
+      {/* Progress Bar */}
+      <div className="max-w-7xl mx-auto px-5 py-4">
+        <ProgressBar 
+          current={currentQuestion + 1} 
+          total={3} // 임시로 3개 질문
+          className="h-[46px]"
+        />
+      </div>
+
+      {/* Survey Content */}
+      {currentModal === null && (
+        <div className="max-w-4xl mx-auto px-5 py-8">
+          <div className="space-y-8">
+            {/* Question 1 */}
+            {currentQuestion === 0 && (
+              <div className="bg-white rounded-[16px] border border-[#c9cbd1] p-6">
+                <div className="mb-6">
+                  <div className="bg-[#b4ede5] rounded-t-[16px] px-6 py-2 -mx-6 -mt-6 mb-4">
+                    <h2 className="text-[22px] font-semibold text-[#434447]">섹션 1</h2>
+                  </div>
+                  <div className="space-y-4">
+                    <div className="bg-white border border-[#c9cbd1] rounded-[4px] p-4">
+                      <h3 className="text-[22px] font-semibold text-[#434447] mb-2">
+                        Q. {survey.title}에 대한 첫 번째 질문입니다.
+                      </h3>
+                      <p className="text-[#91959c] text-[16px]">
+                        질문에 대한 설명을 작성해주세요
+                      </p>
+                    </div>
+                    <div className="space-y-2">
+                      {['선택지 1', '선택지 2', '선택지 3', '선택지 4'].map((option, index) => (
+                        <button
+                          key={index}
+                          onClick={() => handleAnswer(0, option)}
+                          className={`w-full p-4 rounded-[4px] text-left transition-colors ${
+                            answers[0] === option 
+                              ? 'bg-[#5ed7c3] text-white' 
+                              : 'bg-[#f3f4f5] text-[#434447] hover:bg-[#e8e9eb]'
+                          }`}
+                        >
+                          {option}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {/* Question 2 */}
+            {currentQuestion === 1 && (
+              <div className="bg-white rounded-[16px] border border-[#c9cbd1] p-6">
+                <div className="space-y-4">
+                  <div className="bg-white border border-[#c9cbd1] rounded-[4px] p-4">
+                    <h3 className="text-[22px] font-semibold text-[#434447] mb-2">
+                      Q. {survey.title}에 대한 두 번째 질문입니다.
+                    </h3>
+                    <p className="text-[#91959c] text-[16px]">
+                      질문에 대한 설명을 작성해주세요
+                    </p>
+                  </div>
+                  <div className="space-y-2">
+                    {['선택지 A', '선택지 B', '선택지 C', '선택지 D'].map((option, index) => (
+                      <button
+                        key={index}
+                        onClick={() => handleAnswer(1, option)}
+                        className={`w-full p-4 rounded-[4px] text-left transition-colors ${
+                          answers[1] === option 
+                            ? 'bg-[#5ed7c3] text-white' 
+                            : 'bg-[#f3f4f5] text-[#434447] hover:bg-[#e8e9eb]'
+                        }`}
+                      >
+                        {option}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {/* Question 3 */}
+            {currentQuestion === 2 && (
+              <div className="bg-white rounded-[16px] border border-[#c9cbd1] p-6">
+                <div className="space-y-4">
+                  <div className="bg-white border border-[#c9cbd1] rounded-[4px] p-4">
+                    <h3 className="text-[22px] font-semibold text-[#434447] mb-2">
+                      Q. {survey.title}에 대한 세 번째 질문입니다.
+                    </h3>
+                    <p className="text-[#91959c] text-[16px]">
+                      자유롭게 의견을 작성해주세요
+                    </p>
+                  </div>
+                  <textarea
+                    value={answers[2] || ''}
+                    onChange={(e) => handleAnswer(2, e.target.value)}
+                    placeholder="상황에 맞는 설명을 작성해주세요."
+                    className="w-full h-[180px] p-4 bg-[#f3f4f5] border border-[#c9cbd1] rounded-[8px] resize-none focus:outline-none focus:ring-2 focus:ring-[#5ed7c3]"
+                  />
+                </div>
+              </div>
+            )}
+
+            {/* Navigation Buttons */}
+            <div className="flex gap-3">
+              <button
+                onClick={handlePrevious}
+                disabled={currentQuestion === 0}
+                className="flex-1 bg-[#b4ede5] text-[#434447] py-3 px-4 rounded-[8px] font-medium text-[20px] disabled:opacity-50 disabled:cursor-not-allowed hover:bg-[#a0e6d8] transition-colors"
+              >
+                이전
+              </button>
+              <button
+                onClick={handleNext}
+                className="flex-1 bg-[#5ed7c3] text-[#434447] py-3 px-4 rounded-[8px] font-medium text-[20px] hover:bg-[#4bc4b0] transition-colors"
+              >
+                {currentQuestion === 2 ? '완료' : '다음'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Modals */}
+      <PrivacyConsentModal
+        isOpen={currentModal === 'privacy'}
+        onClose={() => handleModalAction('close')}
+        onAgree={() => handleModalAction('agree')}
+      />
+      
+      <ThirdPartyConsentModal
+        isOpen={currentModal === 'thirdParty'}
+        onClose={() => handleModalAction('close')}
+        onAgree={() => handleModalAction('agree')}
+      />
+      
+      <InterviewRequestModal
+        isOpen={currentModal === 'interview'}
+        onClose={() => handleModalAction('close')}
+        onAccept={() => handleModalAction('accept')}
+        userName={survey.surveyor.name}
+        duration="1시간 30분"
+        reward="배달의 민족 2만원 기프티콘"
+      />
+    </div>
+  )
+}


### PR DESCRIPTION
# 설문조사 진행 페이지 및 완료 페이지 구현

## 📌 연관된 이슈

> #34 - 설문조사 진행 페이지 구현

## 🚀 작업 내용

> 이번 PR에서는 설문조사 진행 페이지와 완료 페이지를 구현했습니다.

### 🎯 주요 구현 사항

#### 1. 설문 진행 페이지 (`/surveys/{id}/start`)
- **모달 3개 순차 표시**: 개인정보 동의 → 제3자 동의 → 인터뷰 요청
- **ProgressBar 컴포넌트**: 현재 진행도 시각적 표시
- **설문 질문 화면**: 객관식, 주관식 질문 지원
- **네비게이션**: 이전/다음 버튼으로 질문 간 이동

#### 2. 설문 완료 페이지 (`/surveys/{id}/complete`)
- **포인트 보상 완료 페이지**: 즉시 적립되는 포인트 보상 안내
- **기프티콘 보상 완료 페이지**: 추첨을 통한 기프티콘 보상 안내
- **자동 라우팅**: 설문 완료 시 보상 타입에 따라 적절한 완료 페이지로 이동

#### 3. 컴포넌트 구조
```
src/app/surveys/[id]/start/
├── page.tsx                           # 메인 진행 페이지
├── components/
│   ├── progress-bar.tsx              # 진행도 표시 컴포넌트
│   ├── privacy-consent-modal.tsx     # 개인정보 동의 모달
│   ├── third-party-consent-modal.tsx # 제3자 동의 모달
│   └── interview-request-modal.tsx   # 인터뷰 요청 모달

src/app/surveys/[id]/complete/
├── page.tsx                           # 메인 완료 페이지
└── components/
    ├── points-completion-page.tsx    # 포인트 보상 완료 페이지
    └── gift-completion-page.tsx      # 기프티콘 보상 완료 페이지
```

### 🎨 디자인 구현
- **Figma 디자인 정확 반영**: 제공된 Figma 디자인을 100% 구현
- **반응형 디자인**: 모바일/데스크톱 대응
- **일관된 UI**: 기존 설문 페이지와 일관된 디자인 시스템 적용

### 🔄 사용자 경험 플로우
```
설문 상세 → 설문 시작 → 모달 3개 → 설문 진행 → 완료 페이지
    ↓
보상 타입에 따라:
- 포인트: 즉시 적립 완료 페이지
- 기프티콘: 추첨 안내 완료 페이지
```

## ✅ 변경 사항 체크리스트

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

### 🔍 주요 검토 포인트
1. **모달 순차 표시 로직**: `currentModal` 상태 관리가 올바르게 구현되었는지 확인
2. **ProgressBar 컴포넌트**: 진행도 계산 및 애니메이션이 정상 작동하는지 확인
3. **완료 페이지 라우팅**: URL 파라미터를 통한 보상 정보 전달이 올바른지 확인
4. **타입 안전성**: TypeScript 타입 정의가 적절한지 확인
5. **Figma 디자인 일치도**: 구현된 UI가 디자인과 일치하는지 확인

### 🧪 테스트 권장사항
- 설문 진행 페이지에서 모달 3개가 순차적으로 표시되는지 테스트
- ProgressBar가 질문 진행에 따라 올바르게 업데이트되는지 테스트
- 설문 완료 후 보상 타입에 따라 적절한 완료 페이지로 이동하는지 테스트

## 📢 노트 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요.

### 📋 구현 세부사항

#### 모달 컴포넌트
- **개인정보 동의 모달**: 개인정보 수집 목적, 항목, 보유기간 안내
- **제3자 동의 모달**: 제3자 제공 동의 안내
- **인터뷰 요청 모달**: 인터뷰 참여 여부 선택 (사용자명, 소요시간, 보상 정보 표시)

#### ProgressBar 컴포넌트
- 현재 질문 번호와 전체 질문 수를 표시
- 진행률에 따른 시각적 표시 (애니메이션 포함)
- 중앙에 "현재/전체" 형태로 진행도 표시

#### 완료 페이지
- **포인트 보상**: 획득 포인트 수량 표시, 즉시 적립 안내
- **기프티콘 보상**: 상품 정보, 추첨 일정, 당첨자 수 표시

### 🔗 관련 링크
- Figma 디자인: [Pollet Design System](https://www.figma.com/design/6Wzx5LYrBFXsIBts5cBRgJ/Pollet-Design-System)
- 기존 설문 상세 페이지: `/surveys/[id]`
- 설문 목록 페이지: `/surveys`

### 🚀 다음 단계
1. 실제 API 연동 (설문 답변 저장, 보상 지급)
2. 알림 시스템 (추첨 결과 알림)
3. 마이페이지 연동 (포인트 내역, 기프티콘 현황)
4. 공유 기능 (SNS 공유)